### PR TITLE
Fix dependencies

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,9 +34,10 @@
 		"fabricloader": ">=0.16.10",
 		"java": ">=21",
 		"minecraft": "~1.21.1",
-		"modmenu": "*"
+		"owo": "*",
+		"geckolib": "*"
 	},
 	"suggests": {
-		"another-mod": "*"
+		"modmenu": "*"
 	}
 }


### PR DESCRIPTION
Was doing some bug hunting and noticed that Adorable-Hamster-Pets does not declare dependencies correctly. OwOLib and GeckoLib are both required for the mod to function. ModMenu is not and therefore is optional.

PS: I would make sure you have these declared on your Modrinth version page too. See mod IDs in this pull request.